### PR TITLE
Resize crests in standings table

### DIFF
--- a/Startseite.py
+++ b/Startseite.py
@@ -126,7 +126,7 @@ df = (
 )
 
 # Darstellung für Logos vorbereiten
-df["Logo"] = df["cresturl"].apply(lambda url: f"<img src='{url}' width='25'>")
+df["Logo"] = df["cresturl"].apply(lambda url: f"<img src='{url}' width='50'>")
 df = df.drop(columns=["cresturl"])
 
 # Spaltenreihenfolge definieren
@@ -156,8 +156,8 @@ styled_df = (
         [
             {"selector": "th", "props": "text-align:center; background-color:#f0f0f0;"},
             {"selector": "td", "props": "text-align:center;"},
-            {"selector": "td:nth-child(2)", "props": "text-align:center; width:1%;"},
-            {"selector": "th:nth-child(2)", "props": "width:1%;"},
+            {"selector": "td:nth-child(2)", "props": "text-align:center; width:60px;"},
+            {"selector": "th:nth-child(2)", "props": "width:60px;"},
             {"selector": "table", "props": "width:90%; margin-left:auto; margin-right:auto; border-collapse:collapse;"},
         ]
     )


### PR DESCRIPTION
## Summary
- enlarge team crests shown in the standings table to improve readability
- adjust table column width styling for bigger logos

## Testing
- `python3 -m py_compile Startseite.py`

------
https://chatgpt.com/codex/tasks/task_e_68726484c760832db20fad9f7cc6a89a